### PR TITLE
can't use not exsist account item

### DIFF
--- a/Accounting.Test/AccountTest.vb
+++ b/Accounting.Test/AccountTest.vb
@@ -7,8 +7,6 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
         Dim 資産 As New Asset
         資産.Add(1, "現金")
         Assert.AreEqual(資産.Accounts.Count, 1)
-        Assert.AreEqual(資産.Accounts.First.Title, "現金")
-        Assert.AreEqual(資産.Accounts.First.Code, 1)
     End Sub
 
     <TestMethod()>
@@ -29,7 +27,6 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
 
         '作成方法を問わず、整合性が維持できていることを確認する。
         Assert.AreEqual(資産.Accounts.Count, 2)
-        Assert.AreEqual(資産.Balance, CDec(0))
     End Sub
 
 
@@ -47,7 +44,6 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
 
         '勘定から勘定科目が削除されていないことを確認する。
         Assert.AreEqual(負債.Accounts.Count, 1)
-
     End Sub
 
 End Class

--- a/Accounting.Test/TransactionTest.vb
+++ b/Accounting.Test/TransactionTest.vb
@@ -1,14 +1,22 @@
 ﻿Imports System.Text
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
-
 <TestClass()> Public Class TransactionTest
+
+    Private SetUpAsset As New Asset
+
+
+    <TestInitialize()> Public Sub MyTestInitialize()
+        SetUpAsset.Add(1, "現金")
+    End Sub
+
+
 
     <TestMethod()> Public Sub 取引金額テスト()
         Dim 資産 As New Asset
 
 
-        Dim 貸方 As New Entry(資産, 1, 10000)
-        Dim 借方 As New Entry(資産, 1, -10000)
+        Dim 貸方 As New Entry(資産.GetItem(1), 10000)
+        Dim 借方 As New Entry(資産.GetItem(1), -10000)
 
         Dim entrys As New List(Of Entry)
         entrys.Add(貸方)
@@ -21,11 +29,13 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
     <TestMethod()> Public Sub 複数エントリ取引作成テスト()
         Dim 資産 As New Asset
         Dim 負債 As New Liabilities
+        負債.Add(1, "借入金")
         Dim 費用 As New Expense
+        費用.Add(1, "借入金利息")
 
-        Dim 現金 As New Entry(資産, 1, -10000)
-        Dim 借入 As New Entry(負債, 1, -9000)
-        Dim 利息 As New Entry(費用, 1, 1000)
+        Dim 現金 As New Entry(資産.GetItem(1), -10000)
+        Dim 借入 As New Entry(負債.GetItem(1), -9000)
+        Dim 利息 As New Entry(費用.GetItem(1), 1000)
 
         Dim entrys As New List(Of Entry)
         entrys.Add(現金)
@@ -42,8 +52,8 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
     Public Sub 取引貸借不一致テスト()
 
         Dim 資産 As New Asset
-        Dim 貸方 As New Entry(資産, 1, 10000)
-        Dim 借方 As New Entry(資産, 1, -1000)
+        Dim 貸方 As New Entry(資産.GetItem(1), 10000)
+        Dim 借方 As New Entry(資産.GetItem(1), -1000)
 
         Dim entrys As New List(Of Entry)
         entrys.Add(貸方)
@@ -60,7 +70,7 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
     Public Sub 取引エントリ数不足テスト()
 
         Dim 資産 As New Asset
-        Dim 貸方 As New Entry(資産, 1, 0)
+        Dim 貸方 As New Entry(資産.GetItem(1), 0)
 
         Dim entrys As New List(Of Entry)
         entrys.Add(貸方)
@@ -77,8 +87,8 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
         Dim 資産 As New Asset
         資産.Add(1, "現金")
 
-        Dim 貸方 As New Entry(資産, 2, -10)
-        Dim 借方 As New Entry(資産, 1, 10)
+        Dim 貸方 As New Entry(資産.GetItem(1), -10)
+        Dim 借方 As New Entry(資産.GetItem(1), 10)
 
         Dim entrys As New List(Of Entry)
         entrys.Add(貸方)

--- a/Accounting.Test/TransactionTest.vb
+++ b/Accounting.Test/TransactionTest.vb
@@ -69,4 +69,23 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
         Assert.Fail("エントリ数不足例外が発生しなければなりません。")
     End Sub
 
+
+    <TestMethod()>
+    <ExpectedException(GetType(System.ArgumentException))>
+    Public Sub 未登録勘定科目使用テスト()
+
+        Dim 資産 As New Asset
+        資産.Add(1, "現金")
+
+        Dim 貸方 As New Entry(資産, 2, -10)
+        Dim 借方 As New Entry(資産, 1, 10)
+
+        Dim entrys As New List(Of Entry)
+        entrys.Add(貸方)
+        entrys.Add(借方)
+
+        Dim 取引 As New Transaction(entrys, Now, "未登録勘定科目使用取引")
+        Assert.Fail("未登録勘定科目使用例外が発生しなければなりません。")
+    End Sub
+
 End Class

--- a/Accounting.Test/TransactionTest.vb
+++ b/Accounting.Test/TransactionTest.vb
@@ -4,7 +4,6 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
 
     Private SetUpAsset As New Asset
 
-
     <TestInitialize()> Public Sub MyTestInitialize()
         SetUpAsset.Add(1, "現金")
     End Sub
@@ -12,7 +11,7 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
 
 
     <TestMethod()> Public Sub 取引金額テスト()
-        Dim 資産 As New Asset
+        Dim 資産 = SetUpAsset
 
 
         Dim 貸方 As New Entry(資産.GetItem(1), 10000)
@@ -27,7 +26,7 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
     End Sub
 
     <TestMethod()> Public Sub 複数エントリ取引作成テスト()
-        Dim 資産 As New Asset
+        Dim 資産 = SetUpAsset
         Dim 負債 As New Liabilities
         負債.Add(1, "借入金")
         Dim 費用 As New Expense
@@ -51,7 +50,7 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
     <ExpectedException(GetType(System.ArgumentException))>
     Public Sub 取引貸借不一致テスト()
 
-        Dim 資産 As New Asset
+        Dim 資産 = SetUpAsset
         Dim 貸方 As New Entry(資産.GetItem(1), 10000)
         Dim 借方 As New Entry(資産.GetItem(1), -1000)
 
@@ -69,7 +68,7 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
     <ExpectedException(GetType(System.ArgumentException))>
     Public Sub 取引エントリ数不足テスト()
 
-        Dim 資産 As New Asset
+        Dim 資産 = SetUpAsset
         Dim 貸方 As New Entry(資産.GetItem(1), 0)
 
         Dim entrys As New List(Of Entry)
@@ -84,7 +83,7 @@ Imports Microsoft.VisualStudio.TestTools.UnitTesting
     <ExpectedException(GetType(System.ArgumentException))>
     Public Sub 未登録勘定科目使用テスト()
 
-        Dim 資産 As New Asset
+        Dim 資産 = SetUpAsset
         資産.Add(1, "現金")
 
         Dim 貸方 As New Entry(資産.GetItem(1), -10)

--- a/Accounting/AccountBase.vb
+++ b/Accounting/AccountBase.vb
@@ -51,6 +51,15 @@ Public MustInherit Class AccountBase
     End Sub
 
 
+
+    Public Overloads Function GetItem(Code As Integer) As DetailAccount
+        Return _ChildAccounts.Single(Function(A) A.Code = Code)
+    End Function
+
+    Public Overloads Function GetItem(Title As String) As DetailAccount
+        Return _ChildAccounts.First(Function(A) A.Title = Title)
+    End Function
+
     ''' <summary>
     ''' 指定された明細勘定をこのインスタンスに追加します。
     ''' </summary>

--- a/Accounting/DetailAccount.vb
+++ b/Accounting/DetailAccount.vb
@@ -16,7 +16,6 @@ Public Class DetailAccount
         _Owner.Add(Me)
     End Sub
 
-
     ''' <summary>
     ''' このインスタンスの勘定科目ｺｰﾄﾞを取得します。
     ''' </summary>
@@ -48,6 +47,22 @@ Public Class DetailAccount
     ''' <returns></returns>
     ''' <remarks></remarks>
     Public Function EntryFactry(Amount As Decimal) As Entry
-        Return New Entry(_Owner, _Code, Amount)
+        Return New Entry(Me, Amount)
     End Function
+
+    ''' <summary>
+    ''' 勘定科目が生成する、貸借計算用の式を返します。
+    ''' </summary>
+    ''' <returns>仕訳オブジェクトが貸方に来る場合は引数をそのまま、借方の場合は引数の正負を逆にする関数Func(Of Decimal, Decimal)を返す</returns>
+    Friend Function GetTransactionsBalanceCalculator() As Func(Of Decimal, Decimal)
+        Return _Owner.GetTransactionsBalanceCalculator
+    End Function
+
+    ''' <summary>
+    ''' この勘定科目に仕訳を転記します。
+    ''' </summary>
+    ''' <param name="Entry"></param>
+    Friend Sub Post(Entry As Entry)
+        _Owner.Post(Entry)
+    End Sub
 End Class

--- a/Accounting/Entry.vb
+++ b/Accounting/Entry.vb
@@ -4,16 +4,14 @@ Public Class Entry
 
 
 
-    Private _PostAccount As AccountBase
-    Private _AccountCode As Integer
+    Private _PostAccount As DetailAccount
     Private _Amount As Decimal
 
 
     Private _BalanceCalculator As Func(Of Decimal, Decimal)
 
-    Public Sub New(PostAccount As AccountBase, AccountCode As Integer, Amount As Integer)
+    Public Sub New(PostAccount As DetailAccount, Amount As Integer)
         Me._PostAccount = PostAccount
-        Me._AccountCode = AccountCode
         Me._Amount = Amount
         Me._BalanceCalculator = PostAccount.GetTransactionsBalanceCalculator()
 
@@ -27,17 +25,7 @@ Public Class Entry
         _PostAccount.Post(Me)
     End Sub
 
-    ''' <summary>
-    ''' このインスタンスの科目ｺｰﾄﾞを取得します。
-    ''' </summary>
-    ''' <value></value>
-    ''' <returns></returns>
-    ''' <remarks></remarks>
-    Public ReadOnly Property AccountCode As Integer
-        Get
-            Return _AccountCode
-        End Get
-    End Property
+
 
     ''' <summary>
     ''' このインスタンスで取り扱う金額を取得します。


### PR DESCRIPTION
仕訳のインスタンスで存在しない科目を使用できないよう変更する。
- [x] テストを追加
- [x] 勘定から科目を取得するメソッド
- [x] 仕訳のコンストラクタで科目を指定するように変更
